### PR TITLE
chore(build): upgrade to minecraft 1.21.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'fabric-loom' version '1.15-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Fabric
-minecraft_version=1.21.6
-yarn_mappings=1.21.6+build.1
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.3
 loader_version=0.18.6
-fabric_version=0.128.1+1.21.6
+fabric_version=0.138.4+1.21.10
 
 # Mod
-mod_version=1.21.6-3
+mod_version=1.21.10-1
 maven_group=cn.ussshenzhou
 archives_base_name=NotEnoughBandwidth

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/ChunkMapMixin.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/ChunkMapMixin.java
@@ -1,7 +1,6 @@
 package cn.ussshenzhou.notenoughbandwidth.mixin;
 
 import cn.ussshenzhou.notenoughbandwidth.chunk.CachedChunkTrackingView;
-import net.minecraft.server.network.ChunkFilter;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ChunkTicketManager;
 import net.minecraft.server.world.ChunkTicketType;
@@ -41,7 +40,7 @@ public abstract class ChunkMapMixin {
      */
     @Overwrite
     private void sendWatchPackets(ServerPlayerEntity player) {
-        if (player.getWorld() != this.world) {
+        if (player.getEntityWorld() != this.world) {
             return;
         }
         CachedChunkTrackingView.onUpdateChunkTracking(player, getViewDistance(player), new CachedChunkTrackingView.Context() {
@@ -59,7 +58,7 @@ public abstract class ChunkMapMixin {
             public void putTicket(ChunkPos pos, int ticks) {
                 var ticketType = nebDccTicket.get();
                 if (ticketType == null || ticketType.expiryTicks() != ticks) {
-                    var newType = new ChunkTicketType(ticks, false, ChunkTicketType.Use.LOADING);
+                    var newType = new ChunkTicketType(ticks, ChunkTicketType.FOR_LOADING);
                     nebDccTicket.compareAndSet(ticketType, newType);
                     ticketType = nebDccTicket.get();
                 }

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/network/ModNetworking.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/network/ModNetworking.java
@@ -63,7 +63,7 @@ public class ModNetworking {
         // Client didn't have the chunk despite bloom-filter hit; resend full data.
         ServerPlayNetworking.registerGlobalReceiver(ChunkRequestPayload.TYPE, (payload, context) -> {
             ServerPlayerEntity player = context.player();
-            ServerWorld world = player.getWorld();
+            ServerWorld world = player.getEntityWorld();
             ChunkPos pos = new ChunkPos(payload.chunkX(), payload.chunkZ());
             world.getServer().execute(() -> {
                 var chunk = world.getChunkManager().getWorldChunk(pos.x, pos.z);

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/stat/ModKey.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/stat/ModKey.java
@@ -5,9 +5,11 @@ import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
+import net.minecraft.util.Identifier;
 import org.lwjgl.glfw.GLFW;
 
 public class ModKey {
+    private static final KeyBinding.Category NEB_CATEGORY = KeyBinding.Category.create(Identifier.of("neb", "main"));
     private static KeyBinding statKey;
 
     public static void register() {
@@ -15,7 +17,7 @@ public class ModKey {
                 "key.neb.stat",
                 InputUtil.Type.KEYSYM,
                 GLFW.GLFW_KEY_N,
-                "key.categories.neb"
+                NEB_CATEGORY
         ));
 
         ClientTickEvents.END_CLIENT_TICK.register(client -> {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
   "accessWidener": "neb-fabric.accesswidener",
   "depends": {
     "fabricloader": ">=0.18.0",
-    "minecraft": "~1.21.6",
+    "minecraft": "~1.21.10",
     "java": ">=21",
     "fabric-api": "*"
   }


### PR DESCRIPTION
- Update fabric-loom, fabric-api, and yarn mappings to 1.21.10
- Fix ServerPlayerEntity.getWorld() → getEntityWorld()
- Adapt ChunkTicketType constructor (flags int instead of Use enum)
- Update KeyBinding to use Category record instead of String