### PR TITLE
fix: applyLightData version boundary is 1.21.2, not 1.20.2 (crashes 1.21.1 at startup)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,3 +48,10 @@ subprojects { p ->
         }
     }
 }
+
+def buildAndGather = tasks.register('buildAndGather') {
+    group = 'build'
+    description = 'Build all version subprojects and collect their mod jars into build/libs.'
+    dependsOn collectJars
+    subprojects.each { p -> dependsOn("${p.path}:build") }
+}

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/ClientChunkLightRecomputeMixin.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/ClientChunkLightRecomputeMixin.java
@@ -17,7 +17,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ClientChunkLightRecomputeMixin {
 
     @Inject(method = "applyLightData", at = @At("TAIL"))
-    //#if MC>=12002
+    //#if MC>=12102
     private void nebRecomputeStrippedLight(int x, int z, ClientboundLightUpdatePacketData lightData, boolean trustEdges, CallbackInfo ci) {
     //#else
     //$$ private void nebRecomputeStrippedLight(int x, int z, ClientboundLightUpdatePacketData lightData, CallbackInfo ci) {

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/ClientPlayNetworkHandlerInvoker.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/mixin/ClientPlayNetworkHandlerInvoker.java
@@ -17,7 +17,7 @@ public interface ClientPlayNetworkHandlerInvoker {
     @Invoker("updateLevelChunk")
     void nebLoadChunk(int x, int z, ClientboundLevelChunkPacketData chunkData);
 
-    //#if MC>=12002
+    //#if MC>=12102
     @Invoker("applyLightData")
     void nebReadLightData(int x, int z, ClientboundLightUpdatePacketData lightData, boolean bl);
     //#else

--- a/src/main/java/cn/ussshenzhou/notenoughbandwidth/network/ModNetworking.java
+++ b/src/main/java/cn/ussshenzhou/notenoughbandwidth/network/ModNetworking.java
@@ -228,7 +228,11 @@ public class ModNetworking {
                     if (world != null) {
                         // 26.1: ClientLevel.enqueueChunkUpdate is gone; just run on the client thread.
                         net.minecraft.client.Minecraft.getInstance().execute(() -> {
+                            //#if MC>=12102
                             invoker.nebReadLightData(x, z, lightData, false);
+                            //#else
+                            //$$ invoker.nebReadLightData(x, z, lightData);
+                            //#endif
                             var worldChunk = world.getChunkSource().getChunkNow(x, z);
                             if (worldChunk != null) {
                                 invoker.nebScheduleRenderChunk(worldChunk, x, z);


### PR DESCRIPTION
## Problem

NEB 1.0.2 crashes dedicated servers and clients on MC 1.21.1 at startup with a
mixin injection failure (`Critical injection failure` / `InvalidAccessorException`
against `ClientPacketListener`).

## Root cause

`ClientPacketListener.applyLightData` gained its trailing `boolean` parameter in
**1.21.2**, not 1.20.2:

| Version         | Signature                                                                     |
|-----------------|-------------------------------------------------------------------------------|
| 1.20.1 – 1.21.1 | `applyLightData(int, int, ClientboundLightUpdatePacketData)` (`method_38543`) |
| 1.21.2+         | `applyLightData(int, int, ClientboundLightUpdatePacketData, boolean)`         |

The preprocessor boundary was written as `//#if MC>=12002`, so 1.21.1 (12101)
incorrectly selected the 4-arg form in three places:

- `ClientChunkLightRecomputeMixin` — 4-arg injection handler fails under `defaultRequire: 1`
- `ClientPlayNetworkHandlerInvoker` — 4-arg accessor throws `InvalidAccessorException` at apply time
- `ModNetworking` — cached-chunk replay calls the 4-arg invoker

## Fix

- Boundary `MC>=12002` → `MC>=12102` in the two client mixins
- Split the `ModNetworking` call site on `MC>=12102` (1.21.1 uses the 3-arg form)

## Also included

`buildAndGather` gradle task: builds every version subproject and collects the
jars into `build/libs`, so a per-version breakage can no longer hide behind a
main-project-only build. All 8 subprojects verified to compile:
1.20.1, 1.21.1, 1.21.4, 1.21.6, 1.21.10, 1.21.11, 26.1, 26.2 → BUILD SUCCESSFUL.